### PR TITLE
Check the is_slave return code properly.

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -875,7 +875,9 @@ mysql_monitor() {
     if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then
         # Check if this instance is configured as a slave, and if so
         # check slave status
-        if [ is_slave -o "$OCF_RESKEY_CRM_meta_role" = "Slave" ]; then
+        is_slave
+        rc=$?
+        if [ $rc -eq 0 -o "$OCF_RESKEY_CRM_meta_role" == "Slave" ]; then
             check_slave
         fi
 


### PR DESCRIPTION
Updated my version of the resource agent and it caused the mysql service to stop. Doing a resource cleanup would cause it to retry starting it, but would eventually fail. Tracked it down to the conditional around the check_slave call in the mysql_monitor function. Simplified example below.

``` shell
#!/bin/sh

VAR1="Master"
is_slave() {
    return 1
}

if [ is_slave -o "$VAR1" = "Slave" ]; then                                                                                                                                                                                                    
    echo "Failed"
else
    echo "Passed"
fi
```

$ sh ./test.sh
Failed
