### PR TITLE
Support xtrabackup safe-slave-backup option.

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -87,6 +87,7 @@ OCF_RESKEY_max_slave_lag_default="3600"
 OCF_RESKEY_evict_outdated_slaves_default="false"
 OCF_RESKEY_reader_attribute_default="readable"
 OCF_RESKEY_reader_failcount_default="1"
+OCF_RESKEY_backup_lockfile_default="/var/lock/innobackupex"
 
 
 : ${OCF_RESKEY_binary=${OCF_RESKEY_binary_default}}
@@ -121,6 +122,7 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 : ${OCF_RESKEY_reader_attribute=${OCF_RESKEY_reader_attribute_default}}
 : ${OCF_RESKEY_reader_failcount=${OCF_RESKEY_reader_failcount_default}}
 
+: ${OCF_RESKEY_backup_lockfile=${OCF_RESKEY_backup_lockfile_default}}
 
 #######################################################################
 # Convenience variables
@@ -374,6 +376,28 @@ there are short intermittent issues like clock adjustments in VMs.
 <shortdesc lang="en">Allowed failcount for reader</shortdesc>
 <content type="integer" default="${OCF_RESKEY_reader_failcount_default}" />
 </parameter>
+
+<parameter name="backup_lockfile" unique="1" required="0">
+<longdesc lang="en">
+The path to a file that will be exclusively locked by any backup
+process. The lockfile serves to provide a reliable way of determining
+whether to restart the slave process or not. If a thirdparty process
+locks this file, the agent will fail to lock the file and will not
+start the slave. When this agent is able to lock the file, it is
+assumed that backups are finished and the slave thread should be
+running and will start it.
+
+A typical cron command example would be like:
+flock -xn /var/lock/innobackupex innobackupex --safe-slave-backup /tmp/mysqlbackup
+
+This example will use innobackupex's ability to stop the slave when necessary
+to ensure backup consistency. During this time the agent will not start the
+slave. Once the backup is complete, the lock will automatically expire and
+the agent can start the slave if it isn't already.
+</longdesc>
+<shortdesc lang="en">Path to backup lockfile</shortdesc>
+<content type="string" default="${OCF_RESKEY_backup_lockfile_default}" />
+</parameter>
 </parameters>
 
 <actions>
@@ -558,9 +582,22 @@ check_slave() {
             set_reader_attr 0
             $CRM_MASTER -v 0
 
-            # try to restart slave
-            ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-                -e "START SLAVE"
+            # Check that the flock tool exists first
+            if type flock &>/dev/null; then
+                (
+                    flock -xn 200
+                    if [ $? -eq 0 ]; then
+                        ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+                            -e "START SLAVE"
+                    else
+                        ocf_log info "Unable to lock $OCF_RESKEY_backup_lockfile. Not starting slave."
+                    fi
+                ) 200>$OCF_RESKEY_backup_lockfile
+            else
+                # try to restart slave
+                ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
+                    -e "START SLAVE"
+            fi
 
             # Return success to prevent a restart
             exit $OCF_SUCCESS


### PR DESCRIPTION
Uses the flock tool to ensure that a process is actively doing a backup and when doing so, that the PRM will not restart the slave thread.

The PRM will continue to remove the readable attribute and make it not eligible for promotion.

Once the backup is complete, the PRM will start the slave thread as normal, if the backup tool has not already done so, and the readable attribute will again be true and master score return to normal.

I'm open to comments/suggestions on how things might be improved but this appears to work for me.
