### PR TITLE
Patches to use replication_port, and add replication_options

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -892,7 +892,7 @@ mysql_monitor() {
         # Check if this instance is configured as a slave, and if so
         # check slave status
         
-	master_resource=`$CRM resource list | grep p_mysql | awk '{print $3}'`
+	master_resource=`$CRM resource list | grep p_mysql | awk '{print $3}' | head -n 1`
 	master_exists=`$CRM resource list $master_resource | egrep -c 'Master$'`
         # Are we currently having a master?
         if [ "$master_exists" -eq "0" ]; then

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -701,7 +701,7 @@ unset_master(){
     fi
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "RESET SLAVE /*!50500 ALL */;"
+        -e "RESET SLAVE /*!50516 ALL */;"
     if [ $? -gt 0 ]; then
         ocf_log err "Failed to reset slave"
         exit $OCF_ERR_GENERIC

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -887,6 +887,9 @@ mysql_start() {
     if ocf_is_ms; then
         # Initialize the ReaderVIP attribute, monitor will enable it
         set_reader_attr 0
+
+        # set master_score to 0 in case mysql crashes on startup
+        $CRM_MASTER -v 0
     fi
 
     mysql_status info
@@ -1104,12 +1107,12 @@ mysql_promote() {
 
 mysql_demote() {
     if ! mysql_status err; then
-        return $OCF_NOT_RUNNING
+        $CRM_MASTER -v 0
+    else
+        # Return master preference to default, so the cluster manager gets
+        # a chance to select a new master
+        $CRM_MASTER -v 1
     fi
-
-    # Return master preference to default, so the cluster manager gets
-    # a chance to select a new master
-    $CRM_MASTER -v 1
 }
 
 mysql_notify() {

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -119,10 +119,8 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 : ${OCF_RESKEY_evict_outdated_slaves=${OCF_RESKEY_evict_outdated_slaves_default}}
 
 : ${OCF_RESKEY_reader_attribute=${OCF_RESKEY_reader_attribute_default}}
-<<<<<<< HEAD
 : ${OCF_RESKEY_reader_failcount=${OCF_RESKEY_reader_failcount_default}}
-=======
->>>>>>> upstream/master
+
 
 #######################################################################
 # Convenience variables

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -115,7 +115,7 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 # Convenience variables
 
 MYSQL=$OCF_RESKEY_client_binary
-MYSQL_OPTIONS_LOCAL="-S $OCF_RESKEY_socket --connect_timeout=10"
+MYSQL_OPTIONS_LOCAL="-A -S $OCF_RESKEY_socket --connect_timeout=10"
 MYSQL_OPTIONS_REPL="$MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_replication_user --password=$OCF_RESKEY_replication_passwd"
 MYSQL_OPTIONS_TEST="$MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_test_user --password=$OCF_RESKEY_test_passwd"
 MYSQL_TOO_MANY_CONN_ERR=1040

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -895,7 +895,7 @@ mysql_monitor() {
 	master_resource=`$CRM resource list | grep p_mysql | awk '{print $3}' | head -n 1`
 	master_exists=`$CRM resource list $master_resource | egrep -c 'Master$'`
         # Are we currently having a master?
-        if [ "$master_exists" -eq "0" ]; then
+        if [ "$master_exists" -ne "0" ]; then
             is_slave
             rc=$?
             if [ $rc -eq 0 -o "$OCF_RESKEY_CRM_meta_role" = "Slave" ]; then

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -709,7 +709,7 @@ unset_master(){
     fi
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "RESET SLAVE;"
+        -e "RESET SLAVE /*!50500 ALL */;"
     if [ $? -gt 0 ]; then
         ocf_log err "Failed to reset slave"
         exit $OCF_ERR_GENERIC

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -568,7 +568,8 @@ check_slave() {
         fi
 
         # is the slave ok to have a VIP on it
-        if [ -z $secs_behind ]; then
+        test $secs_behind -eq 0 2>/dev/null
+        if [ $? -eq 2 ]; then
             set_reader_attr 0
         else
             if [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
@@ -1132,6 +1133,14 @@ mysql_notify() {
             # The master has completed its promotion. Now is a good
             # time to check whether our replication slave is working
             # correctly.
+            # Is the notification for our set
+            notify_resource=`echo $OCF_RESKEY_CRM_meta_notify_promote_resource|cut -d: -f1`
+            my_resource=`echo $OCF_RESOURCE_INSTANCE|cut -d: -f1`
+            if [ $notify_resource != ${my_resource} ]; then
+                ocf_log debug "Notification is not for us"
+                return $OCF_SUCCESS
+            fi
+
             master_host=`echo $OCF_RESKEY_CRM_meta_notify_promote_uname|tr -d " "`
             if [ "$master_host" = ${HOSTNAME} ]; then
                 ocf_log info "This will be the new master, ignoring post-promote notification."
@@ -1157,6 +1166,14 @@ mysql_notify() {
             return $OCF_SUCCESS
         ;;
         'pre-demote')
+            # Is the notification for our set
+            notify_resource=`echo $OCF_RESKEY_CRM_meta_notify_demote_resource|cut -d: -f1`
+            my_resource=`echo $OCF_RESOURCE_INSTANCE|cut -d: -f1`
+            if [ $notify_resource != ${my_resource} ]; then
+                ocf_log debug "Notification is not for us"
+                return $OCF_SUCCESS
+            fi
+
             demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
             if [ $demote_host = ${HOSTNAME} ]; then
                 ocf_log info "post-demote notification for $demote_host"
@@ -1184,10 +1201,18 @@ mysql_notify() {
             return $OCF_SUCCESS
         ;;
         'post-demote')
+            # Is the notification for our set
+            notify_resource=`echo $OCF_RESKEY_CRM_meta_notify_demote_resource|cut -d: -f1`
+            my_resource=`echo $OCF_RESOURCE_INSTANCE|cut -d: -f1`
+            if [ $notify_resource != ${my_resource} ]; then
+                ocf_log debug "Notification is not for us"
+                return $OCF_SUCCESS
+            fi
+
             demote_host=`echo $OCF_RESKEY_CRM_meta_notify_demote_uname|tr -d " "`
             if [ $demote_host = ${HOSTNAME} ]; then
-                ocf_log info "Ignoring post-demote notification for my own demotion."
-                return $OCF_SUCCESS
+               ocf_log info "Ignoring post-demote notification for my own demotion."
+               return $OCF_SUCCESS
             fi
             ocf_log info "post-demote notification for $demote_host."
             # The former master has just been gracefully demoted.

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -864,9 +864,13 @@ mysql_monitor() {
             -e "SELECT COUNT(*) FROM $OCF_RESKEY_test_table"
         rc=$?
 
-        if [ $rc -ne 0 ]; then
-            ocf_log err "Failed to select from $test_table";
-            return $OCF_ERR_GENERIC;
+        if [ $rc -ne "$MYSQL_TOO_MANY_CONN_ERR" ]; then
+            if [ $rc -ne 0 ]; then
+                ocf_log err "Failed to select from $test_table";
+                return $OCF_ERR_GENERIC;
+            fi
+        else
+            ocf_log info "Master hit max_connections"
         fi
     fi
 

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -631,7 +631,7 @@ set_master() {
     # reset with RESET MASTER.
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "CHANGE MASTER TO MASTER_HOST='$new_master', \
+        -e "STOP SLAVE;CHANGE MASTER TO MASTER_HOST='$new_master', \
         MASTER_USER='$OCF_RESKEY_replication_user', \
         MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $master_params"
 }

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -357,8 +357,8 @@ whether a node is usable for clients to read from.</shortdesc>
 <parameter name="reader_failcount" unique="1" required="0">
 <longdesc lang="en">
 The number of times a monitor operation can find the slave
-to be unsuitable for replication before failing.  Useful if
-there are short intermittent issue like clock adjustments in VM.
+to be unsuitable for reader VIP before failing.  Useful if
+there are short intermittent issues like clock adjustments in VMs.
 </longdesc>
 <shortdesc lang="en">Allowed failcount for reader</shortdesc>
 <content type="integer" default="${OCF_RESKEY_reader_failcount_default}" />

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -1090,7 +1090,7 @@ mysql_promote() {
     # Existing master gets a higher-than-default master preference, so
     # the cluster manager does not shuffle the master role around
     # unnecessarily
-    $CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1))
+    $CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1000))
 
     # A master can accept reads
     set_reader_attr 1

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -890,7 +890,7 @@ mysql_monitor() {
         # check slave status
         is_slave
         rc=$?
-        if [ $rc -eq 0 -o "$OCF_RESKEY_CRM_meta_role" == "Slave" ]; then
+        if [ $rc -eq 0 -o "$OCF_RESKEY_CRM_meta_role" = "Slave" ]; then
             check_slave
         fi
 

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -680,6 +680,7 @@ unset_master(){
         -e "STOP SLAVE IO_THREAD"
     if [ $? -gt 0 ]; then
         ocf_log err "Error stopping slave IO thread"
+        rm -f $tmpfile
         exit $OCF_ERR_GENERIC
     fi
 
@@ -1199,6 +1200,7 @@ mysql_notify() {
                     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
                         -e "KILL ${thread}"
                 done
+                rm -f $tmpfile
             else
                ocf_log info "Ignoring post-demote notification execpt for my own demotion."
             fi

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -469,9 +469,10 @@ get_slave_info() {
             # Instance produced an empty "SHOW SLAVE STATUS" output --
             # instance is not a slave
             ocf_log err "check_slave invoked on an instance that is not a replication slave."
+	    rm -f $tmpfile
             return $OCF_ERR_GENERIC
         fi
-
+        rm -f $tmpfile
         return $OCF_SUCCESS
     fi
 }
@@ -494,13 +495,16 @@ check_slave() {
 
             # Just pull the reader VIP away, killing MySQL here would be pretty evil
             # on a loaded server
-
             set_reader_attr 0
+
+            #Since replication is broken, not suitable to be a master
+            $CRM_MASTER -v 0
+
             exit $OCF_SUCCESS
 
         fi
 
-        # If we got max_connections, let's remove the vip
+        # If we got max_connections, let's only remove the vip
         if [ $last_errno -eq "$MYSQL_TOO_MANY_CONN_ERR" ]; then
             set_reader_attr 0
             exit $OCF_SUCCESS
@@ -518,7 +522,6 @@ check_slave() {
             if [ "$master_host" != "$new_master" ]; then
                # Not pointing to the right master, not good, removing the VIPs
                set_reader_attr 0
-
                exit $OCF_SUCCESS
             fi
 
@@ -533,6 +536,7 @@ check_slave() {
 
             # Remove reader vip
             set_reader_attr 0
+            $CRM_MASTER -v 0
 
             # try to restart slave
             ocf_run $MYSQL $MYSQL_OPTIONS_REPL \

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -655,7 +655,8 @@ set_master() {
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
         -e "STOP SLAVE;CHANGE MASTER TO MASTER_HOST='$new_master', \
-        MASTER_USER='$OCF_RESKEY_replication_user        MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $OCF_RESKEY_replication_options $master_params"
+        MASTER_USER='$OCF_RESKEY_replication_user', \
+        MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $OCF_RESKEY_replication_options $master_params"
 }
 
 unset_master(){

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -888,10 +888,14 @@ mysql_monitor() {
     if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then
         # Check if this instance is configured as a slave, and if so
         # check slave status
-        is_slave
-        rc=$?
-        if [ $rc -eq 0 -o "$OCF_RESKEY_CRM_meta_role" = "Slave" ]; then
-            check_slave
+        
+        # Are we currently having a master?
+        if [ "a$OCF_RESKEY_CRM_meta_notify_start_uname" != "a" ]; then
+            is_slave
+            rc=$?
+            if [ $rc -eq 0 -o "$OCF_RESKEY_CRM_meta_role" = "Slave" ]; then
+                check_slave
+            fi
         fi
 
         # Check for test table

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -655,6 +655,7 @@ set_master() {
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
         -e "STOP SLAVE;CHANGE MASTER TO MASTER_HOST='$new_master', \
+        MASTER_PORT=$OCF_RESKEY_replication_port, \
         MASTER_USER='$OCF_RESKEY_replication_user', \
         MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $OCF_RESKEY_replication_options $master_params"
 }

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -442,8 +442,7 @@ parse_slave_info() {
 }
 
 get_slave_info() {
-    # Warning: this sets $tmpfile and LEAVE this file! You must delete it after use!
-    local mysql_options
+    local mysql_options tmpfile
             
     if [ "$master_log_file" -a "$master_host" ]; then
         # variables are already defined, get_slave_info has been run before
@@ -491,7 +490,6 @@ check_slave() {
             # diverged from its master. Make sure this resource
             # doesn't restart in place.
             ocf_log err "MySQL instance configured for replication, but replication has failed."
-            ocf_log err "See $tmpfile for details"
 
             # Just pull the reader VIP away, killing MySQL here would be pretty evil
             # on a loaded server
@@ -532,7 +530,6 @@ check_slave() {
             # good thing. Try to recoved by restarting the SQL thread
             # and remove reader vip.  Prevent MySQL restart.
             ocf_log err "MySQL Slave SQL threads currently not running."
-            ocf_log err "See $tmpfile for details"
 
             # Remove reader vip
             set_reader_attr 0
@@ -551,7 +548,6 @@ check_slave() {
             # behind. Let's check our lag.
             if [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
                 ocf_log err "MySQL Slave is $secs_behind seconds behind master (allowed maximum: $OCF_RESKEY_max_slave_lag)."
-                ocf_log err "See $tmpfile for details"
 
                 # Remove reader vip
                 set_reader_attr 0
@@ -584,12 +580,10 @@ check_slave() {
         fi
 
         ocf_log debug "MySQL instance running as a replication slave"
-        rm -f $tmpfile
     else
         # Instance produced an empty "SHOW SLAVE STATUS" output --
         # instance is not a slave
         # TODO: Needs to handle when get_slave_info will return too many connections error
-        rm -f $tmpfile
         ocf_log err "check_slave invoked on an instance that is not a replication slave."
         exit $OCF_ERR_GENERIC
     fi
@@ -608,7 +602,6 @@ set_master() {
         #	master_params=", MASTER_LOG_FILE='$master_log_file', \
         #	    MASTER_LOG_POS=$master_log_pos"
         ocf_log info "Kept master pos for $master_host : $master_log_file:$master_log_pos"
-        rm -f $tmpfile
         return
     else
         master_log_file=`$CRM_ATTR_REPL_INFO --query  -q | cut -d'|' -f2`
@@ -630,7 +623,6 @@ set_master() {
         -e "CHANGE MASTER TO MASTER_HOST='$new_master', \
         MASTER_USER='$OCF_RESKEY_replication_user', \
         MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $master_params"
-    rm -f $tmpfile
 }
 
 unset_master(){

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -474,7 +474,7 @@ get_slave_info() {
             slave_io=`parse_slave_info Slave_IO_Running $tmpfile`
             last_errno=`parse_slave_info Last_Errno $tmpfile`
             secs_behind=`parse_slave_info Seconds_Behind_Master $tmpfile`
-            ocf_log debug "MySQL instance running as a replication slave"
+            ocf_log debug "MySQL instance has a non empty slave status"
         else
             # Instance produced an empty "SHOW SLAVE STATUS" output --
             # instance is not a slave
@@ -875,7 +875,7 @@ mysql_monitor() {
     if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then
         # Check if this instance is configured as a slave, and if so
         # check slave status
-        if is_slave; then
+        if [ is_slave -o "$OCF_RESKEY_CRM_meta_role" = "Slave" ]; then
             check_slave
         fi
 

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -79,6 +79,7 @@ OCF_RESKEY_replication_port_default="3306"
 OCF_RESKEY_max_slave_lag_default="3600"
 OCF_RESKEY_evict_outdated_slaves_default="false"
 OCF_RESKEY_reader_attribute_default="readable"
+OCF_RESKEY_reader_failcount_default="1"
 
 : ${OCF_RESKEY_binary=${OCF_RESKEY_binary_default}}
 MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
@@ -110,6 +111,7 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 : ${OCF_RESKEY_evict_outdated_slaves=${OCF_RESKEY_evict_outdated_slaves_default}}
 
 : ${OCF_RESKEY_reader_attribute=${OCF_RESKEY_reader_attribute_default}}
+: ${OCF_RESKEY_reader_failcount=${OCF_RESKEY_reader_failcount_default}}
 
 #######################################################################
 # Convenience variables
@@ -351,6 +353,15 @@ This parameter is only meaningful in master/slave set configurations.
 <shortdesc lang="en">Sets the node attribute that determines
 whether a node is usable for clients to read from.</shortdesc>
 <content type="string" default="${OCF_RESKEY_reader_attribute_default}" />
+</parameter>
+<parameter name="reader_failcount" unique="1" required="0">
+<longdesc lang="en">
+The number of times a monitor operation can find the slave
+to be unsuitable for replication before failing.  Useful if
+there are short intermittent issue like clock adjustments in VM.
+</longdesc>
+<shortdesc lang="en">Allowed failcount for reader</shortdesc>
+<content type="integer" default="${OCF_RESKEY_reader_failcount_default}" />
 </parameter>
 </parameters>
 
@@ -720,9 +731,18 @@ set_reader_attr() {
     local curr_attr_value
 
     curr_attr_value=$(get_reader_attr)
-
-    if [ "$curr_attr_value" -ne "$1" ]; then
-        $CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} -v $1
+    
+    if [ "$1" -eq "0" ]; then
+        if [ "$curr_attr_value" -gt "0" ]; then
+            curr_attr_value=$((${curr_attr_value}-1))    
+            $CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} -v $curr_attr_value
+        else
+            $CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} -v 0
+        fi
+    else
+        if [ "$curr_attr_value" -ne "$OCF_RESKEY_reader_failcount" ]; then
+            $CRM_ATTR -l reboot --name ${OCF_RESKEY_reader_attribute} -v $OCF_RESKEY_reader_failcount
+        fi
     fi
 
 }

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -946,7 +946,7 @@ mysql_start() {
     #chgrp -R $OCF_RESKEY_group $OCF_RESKEY_datadir
     mysql_extra_params=
     if ocf_is_ms; then
-        mysql_extra_params="--skip-slave-start"
+        mysql_extra_params="$mysql_extra_params --skip-slave-start --read-only"
     fi
 
     ${OCF_RESKEY_binary} --defaults-file=$OCF_RESKEY_config \
@@ -982,7 +982,7 @@ mysql_start() {
         # We're configured as a stateful resource. We must start as
         # slave by default. At this point we don't know if the CRM has
         # already promoted a master. So, we simply start in read only
-        # mode.
+        # mode.  Should already be from command line.
         set_read_only on
 
         # Now, let's see whether there is a master. We might be a new

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -1076,8 +1076,8 @@ mysql_promote() {
     if ( ! mysql_status err ); then
         return $OCF_NOT_RUNNING
     fi
-    ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
-        -e "STOP SLAVE"
+
+    unset_master
 
     # Set Master Info in CIB, cluster level attribute
     update_data_master_status

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -875,7 +875,9 @@ mysql_monitor() {
     if [ $OCF_CHECK_LEVEL -gt 0 -a -n "$OCF_RESKEY_test_table" ]; then
         # Check if this instance is configured as a slave, and if so
         # check slave status
-        if [ is_slave -o "$OCF_RESKEY_CRM_meta_role" = "Slave" ]; then
+        is_slave
+        rc=$?
+        if [ $rc -eq 0 -o "$OCF_RESKEY_CRM_meta_role" == "Slave" ]; then
             check_slave
         fi
 

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -655,7 +655,10 @@ unset_master(){
     # host, then there's nothing to do. But we do log a warning as
     # no-one but the CRM should be touching the MySQL master/slave
     # configuration.
-    if ! is_slave; then
+
+    is_slave
+    rc=$?
+    if [ $rc -ne 0 ]; then
         ocf_log warn "Attempted to unset the replication master on an instance that is not configured as a replication slave"
         return $OCF_SUCCESS
     fi

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -42,6 +42,7 @@
 #   OCF_RESKEY_replication_user
 #   OCF_RESKEY_replication_passwd
 #   OCF_RESKEY_replication_port
+#   OCF_RESKEY_replication_options
 #   OCF_RESKEY_max_slave_lag
 #   OCF_RESKEY_evict_outdated_slaves
 #   OCF_RESKEY_reader_attribute
@@ -114,6 +115,7 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 : ${OCF_RESKEY_replication_user=${OCF_RESKEY_replication_user_default}}
 : ${OCF_RESKEY_replication_passwd=${OCF_RESKEY_replication_passwd_default}}
 : ${OCF_RESKEY_replication_port=${OCF_RESKEY_replication_port_default}}
+: ${OCF_RESKEY_replication_options=${OCF_RESKEY_replication_options_default}}
 
 : ${OCF_RESKEY_max_slave_lag=${OCF_RESKEY_max_slave_lag_default}}
 : ${OCF_RESKEY_evict_outdated_slaves=${OCF_RESKEY_evict_outdated_slaves_default}}
@@ -321,6 +323,15 @@ The port on which the Master MySQL instance is listening.
 </longdesc>
 <shortdesc lang="en">MySQL replication port</shortdesc>
 <content type="string" default="${OCF_RESKEY_replication_port_default}" />
+</parameter>
+
+<parameter name="replication_options" unique="0" required="0">
+<longdesc lang="en">
+Extra options to pass to CHANGE MASTER, be sure to pass a preceeding comma.  Handy for SSL, for example:
+replication_options=", MASTER_SSL=1, MASTER_SSL_CA='/path/to/ca.crt'"
+</longdesc>
+<shortdesc lang="en">MySQL replication options</shortdesc>
+<content type="string" default="${OCF_RESKEY_replication_options_default}" />
 </parameter>
 
 <parameter name="max_slave_lag" unique="0" required="0">
@@ -644,8 +655,7 @@ set_master() {
 
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
         -e "STOP SLAVE;CHANGE MASTER TO MASTER_HOST='$new_master', \
-        MASTER_USER='$OCF_RESKEY_replication_user', \
-        MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $master_params"
+        MASTER_USER='$OCF_RESKEY_replication_user        MASTER_PASSWORD='$OCF_RESKEY_replication_passwd' $OCF_RESKEY_replication_options $master_params"
 }
 
 unset_master(){

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -39,6 +39,13 @@
 #   OCF_RESKEY_log
 #   OCF_RESKEY_pid
 #   OCF_RESKEY_socket
+#   OCF_RESKEY_replication_user
+#   OCF_RESKEY_replication_passwd
+#   OCF_RESKEY_replication_port
+#   OCF_RESKEY_max_slave_lag
+#   OCF_RESKEY_evict_outdated_slaves
+#   OCF_RESKEY_reader_attribute
+#   OCF_RESKEY_reader_failcount
 
 #######################################################################
 # Initialization:
@@ -81,6 +88,7 @@ OCF_RESKEY_evict_outdated_slaves_default="false"
 OCF_RESKEY_reader_attribute_default="readable"
 OCF_RESKEY_reader_failcount_default="1"
 
+
 : ${OCF_RESKEY_binary=${OCF_RESKEY_binary_default}}
 MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 
@@ -111,12 +119,16 @@ MYSQL_BINDIR=`dirname ${OCF_RESKEY_binary}`
 : ${OCF_RESKEY_evict_outdated_slaves=${OCF_RESKEY_evict_outdated_slaves_default}}
 
 : ${OCF_RESKEY_reader_attribute=${OCF_RESKEY_reader_attribute_default}}
+<<<<<<< HEAD
 : ${OCF_RESKEY_reader_failcount=${OCF_RESKEY_reader_failcount_default}}
+=======
+>>>>>>> upstream/master
 
 #######################################################################
 # Convenience variables
 
 MYSQL=$OCF_RESKEY_client_binary
+
 MYSQL_OPTIONS_LOCAL="-A -S $OCF_RESKEY_socket --connect_timeout=10"
 MYSQL_OPTIONS_REPL="$MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_replication_user --password=$OCF_RESKEY_replication_passwd"
 MYSQL_OPTIONS_TEST="$MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_test_user --password=$OCF_RESKEY_test_passwd"
@@ -453,6 +465,7 @@ parse_slave_info() {
 }
 
 get_slave_info() {
+
     local mysql_options tmpfile
             
     if [ "$master_log_file" -a "$master_host" ]; then
@@ -620,7 +633,7 @@ set_master() {
         if [ -n "$master_log_file" -a -n "$master_log_pos" ]; then
             master_params=", MASTER_LOG_FILE='$master_log_file', \
             MASTER_LOG_POS=$master_log_pos"
-            ocf_log info "Restored master pos for $new_master_host : $master_log_file:$master_log_pos"
+            ocf_log info "Restored master pos for $new_master : $master_log_file:$master_log_pos"
         fi
     fi
 
@@ -721,7 +734,6 @@ unset_master(){
 
 # Start replication as slave
 start_slave() {
-
     ocf_run $MYSQL $MYSQL_OPTIONS_REPL \
         -e "START SLAVE"
 }
@@ -912,6 +924,7 @@ mysql_start() {
 
         # set master_score to 0 in case mysql crashes on startup
         $CRM_MASTER -v 0
+
     fi
 
     mysql_status info
@@ -1108,6 +1121,7 @@ mysql_promote() {
 
     unset_master
 
+
     # Set Master Info in CIB, cluster level attribute
     update_data_master_status
     master_info="$(get_local_ip)|$(get_master_status File)|$(get_master_status Position)"
@@ -1120,6 +1134,9 @@ mysql_promote() {
     # the cluster manager does not shuffle the master role around
     # unnecessarily
     $CRM_MASTER -v $((${OCF_RESKEY_max_slave_lag}+1000))
+
+    # A master can accept reads
+    set_reader_attr 1
 
     # A master can accept reads
     set_reader_attr 1
@@ -1159,6 +1176,7 @@ mysql_notify() {
             # The master has completed its promotion. Now is a good
             # time to check whether our replication slave is working
             # correctly.
+
             # Is the notification for our set
             notify_resource=`echo $OCF_RESKEY_CRM_meta_notify_promote_resource|cut -d: -f1`
             my_resource=`echo $OCF_RESOURCE_INSTANCE|cut -d: -f1`

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -137,6 +137,7 @@ HOSTNAME=`uname -n`
 CRM_ATTR="${HA_SBIN_DIR}/crm_attribute -N $HOSTNAME "
 INSTANCE_ATTR_NAME=`echo ${OCF_RESOURCE_INSTANCE}| awk -F : '{print $1}'`
 CRM_ATTR_REPL_INFO="${HA_SBIN_DIR}/crm_attribute --type crm_config --name ${INSTANCE_ATTR_NAME}_REPL_INFO -s mysql_replication"
+CRM="${HA_SBIN_DIR}/crm"
 
 #######################################################################
 
@@ -867,6 +868,8 @@ mysql_status() {
 mysql_monitor() {
     local rc
     local status_loglevel="err"
+    local master_resource
+    local master_exists
 
     # Set loglevel to info during probe
     if ocf_is_probe; then
@@ -889,8 +892,10 @@ mysql_monitor() {
         # Check if this instance is configured as a slave, and if so
         # check slave status
         
+	master_resource=`$CRM resource list | grep p_mysql | awk '{print $3}'`
+	master_exists=`$CRM resource list $master_resource | egrep -c 'Master$'`
         # Are we currently having a master?
-        if [ "a$OCF_RESKEY_CRM_meta_notify_start_uname" != "a" ]; then
+        if [ "$master_exists" -eq "0" ]; then
             is_slave
             rc=$?
             if [ $rc -eq 0 -o "$OCF_RESKEY_CRM_meta_role" = "Slave" ]; then

--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -39,12 +39,6 @@
 #   OCF_RESKEY_log
 #   OCF_RESKEY_pid
 #   OCF_RESKEY_socket
-#   OCF_RESKEY_replication_user
-#   OCF_RESKEY_replication_passwd
-#   OCF_RESKEY_replication_port
-#   OCF_RESKEY_max_slave_lag
-#   OCF_RESKEY_evict_outdated_slaves
-#   OCF_RESKEY_reader_attribute
 
 #######################################################################
 # Initialization:
@@ -574,10 +568,14 @@ check_slave() {
         fi
 
         # is the slave ok to have a VIP on it
-        if [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
+        if [ -z $secs_behind ]; then
             set_reader_attr 0
         else
-            set_reader_attr 1
+            if [ $secs_behind -gt $OCF_RESKEY_max_slave_lag ]; then
+                set_reader_attr 0
+            else
+                set_reader_attr 1
+            fi
         fi
 
         ocf_log debug "MySQL instance running as a replication slave"
@@ -613,7 +611,7 @@ set_master() {
         if [ -n "$master_log_file" -a -n "$master_log_pos" ]; then
             master_params=", MASTER_LOG_FILE='$master_log_file', \
             MASTER_LOG_POS=$master_log_pos"
-            ocf_log info "Restored master pos for $new_master : $master_log_file:$master_log_pos"
+            ocf_log info "Restored master pos for $new_master_host : $master_log_file:$master_log_pos"
         fi
     fi
 


### PR DESCRIPTION
replication_port was not being used in the CHANGE MASTER, that is fixed.

I also added a 'replication_options' option so I can provide arbitrary arguments to the CHANGE MASTER, for example enabling SSL replication:

replication_options=", MASTER_SSL=1, MASTER_SSL_CA='/etc/mysql/CA.pem', MASTER_SSL_CERT='/etc/mysql/server.pem', MASTER_SSL_KEY='/etc/mysql/server.key'"

The only messy bit is the preceding comma.
