### PR TITLE
Redirect stderr > dev/null when looking for master

### DIFF
--- a/heartbeat/mysql
+++ b/heartbeat/mysql
@@ -950,7 +950,7 @@ mysql_monitor() {
 
         master_resource=`$CRM resource list | grep $INSTANCE_ATTR_NAME | awk '{print $3}' | head -n 1`
         if [[ "$OCF_RESKEY_crm_feature_set" > "3.0.5" ]]; then
-            master_exists=`$CRM resource list $master_resource | egrep -c 'Master$'`
+            master_exists=`$CRM resource list $master_resource 2>/dev/null | egrep -c 'Master$'`
         else
             master_exists=`$CRM resource show | grep -A2 $master_resource | grep -c Masters`
         fi


### PR DESCRIPTION
Prevent extraneous output from going to corosync log file.

When I have one out of three nodes in standby, the corosync log gets filled with stderr logs like so:

Feb 01 10:10:13 domain1.com lrmd: [6770]: info: RA output: (mysql_prm:0:monitor:stderr) resource ms_mysql is NOT running
Feb 01 10:10:18 domain1.com lrmd: [6770]: info: RA output: (mysql_prm:0:monitor:stderr) resource ms_mysql is NOT running

This if from the output of `crm resource list ms_mysql`

```
resource ms_mysql is running on: domain1.com Master
resource ms_mysql is NOT running
resource ms_mysql is running on: domain3.com
```

The `NOT running` line is stderr output and is being caught and logged to corosync's log file.

Redirect this command's stderr to dev/null to prevent this output.
